### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/thepivot88/5c04d37b-39ed-40f3-991f-dead29948797/d99d73b1-564f-417b-b6d2-162253d2bc4d/_apis/work/boardbadge/9af7cda2-f6f7-47b0-b5e0-b3a092fbb62a)](https://dev.azure.com/thepivot88/5c04d37b-39ed-40f3-991f-dead29948797/_boards/board/t/d99d73b1-564f-417b-b6d2-162253d2bc4d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/thepivot88/5c04d37b-39ed-40f3-991f-dead29948797/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.